### PR TITLE
docs(compat): fix typo in readme

### DIFF
--- a/compat/README.md
+++ b/compat/README.md
@@ -1,6 +1,6 @@
 # RxJS Compatibility Package
 
-This package is required to get backwards compatibility with RxJS pervious to version 6. It contains the imports to add operators to `Observable.prototype` and creation methods to `Observable`. This is what allows, for instance, dot-chaining:
+This package is required to get backwards compatibility with RxJS previous to version 6. It contains the imports to add operators to `Observable.prototype` and creation methods to `Observable`. This is what allows, for instance, dot-chaining:
 
 ```
 Observable.interval(1)


### PR DESCRIPTION
fix typo in readme referring to previous (pervious) RxJS versions

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Simply fixes a typo I noticed in `compat`'s README.

**Related issue (if exists):**
